### PR TITLE
Add a Decroate() method to GameModels

### DIFF
--- a/BannerLib.Gameplay/Models/GameModels.cs
+++ b/BannerLib.Gameplay/Models/GameModels.cs
@@ -99,6 +99,26 @@ namespace BannerLib.Gameplay.Models
         public static void ReplaceAll<TBaseReplace, TReplacement>(this IGameStarter starter)
             where TBaseReplace : GameModel where TReplacement : GameModel, new() =>
             ReplaceAll<TBaseReplace, TReplacement>(starter, new TReplacement());
+
+        /// <summary>
+        /// Decorates an existing model with a given decorator that is produced by the given function
+        /// </summary>
+        /// <typeparam name="TDecoratee"></typeparam>
+        /// <typeparam name="TDecorater"></typeparam>
+        /// <param name="starter"></param>
+        /// <param name="decoraterCtor">Functions which creates the decorator from the given model</param>
+        public static void Decorate<TDecoratee, TDecorater>(this IGameStarter starter, Func<TDecoratee, TDecorater> decoraterCtor)
+            where TDecoratee : GameModel where TDecorater : TDecoratee
+        {
+            var baseType = typeof(TDecoratee);
+            var model = starter.Models
+                .OfType<TDecoratee>()
+                .SingleOrDefault();
+            if (model == null)
+                throw new ArgumentException($"No model or multiple models registered with type '{baseType.Name}'. It must be exactly ONE model with this type to decorate it!");
+            var decorater = decoraterCtor(model);
+            starter.Replace<TDecoratee, TDecorater>(decorater);
+        }
         
         /// <summary>
         /// 


### PR DESCRIPTION
With this it is a bit easier to add a decorator ([GoF](https://en.wikipedia.org/wiki/Decorator_pattern)) to an existing model. It replaces the model in the end, but the original model is passed to teh decorator.

With this tow mods could override the same model but different methods, but if the override the same method than it would depend (probably) on the load order what happens.

One question is: Should there be decorators for the common models already or must the user roll their own? Currently there are none, but could be added more-or-less easily.

**Example**:

In `OnGameStart`:
```csharp
campaign.Decorate((WorkshopModel m) => new GuildWorkshopModelDecorator(m));
```
The decorator:
```csharp
public class GuildWorkshopModelDecorator : WorkshopModel
{
    private readonly WorkshopModel model;

    public GuildWorkshopModelDecorater(WorkshopModel model)
    {
        this.model = model;
    }

    // other methods omitted  for brevity...

    public override int GetMaxWorkshopCountForPlayer()
        => int.MaxValue;
}
```
